### PR TITLE
Rename LONG to V_LONG and SHORT to V_SHORT

### DIFF
--- a/x6/groestl/aesni/hash-groestl.c
+++ b/x6/groestl/aesni/hash-groestl.c
@@ -89,9 +89,9 @@ HashReturn_gr init_groestl(hashState_groestl* ctx) {
   ctx->columns = COLS;
   ctx->statesize = SIZE;
 #if (LENGTH <= 256)
-    ctx->v = SHORT;
+    ctx->v = V_SHORT;
 #else
-    ctx->v = LONG;
+    ctx->v = V_LONG;
 #endif
 
   SET_CONSTANTS();

--- a/x6/groestl/aesni/hash-groestl.h
+++ b/x6/groestl/aesni/hash-groestl.h
@@ -77,7 +77,7 @@ typedef crypto_uint64 u64;
    (ROTL64(a,56) & li_64(FF000000FF000000)))
 #endif /* IS_LITTLE_ENDIAN */
 
-typedef enum { LONG, SHORT } Var;
+typedef enum { V_LONG, V_SHORT } Var;
 
 /* NIST API begin */
 


### PR DESCRIPTION
`LONG` and `SHORT` happen to be already defined in some Windows setups. After this refactoring `darkcoin-cpuminer-1.3-avx-aes` can be built on those machines as well.
